### PR TITLE
Sample now working wth DX10+ hardware

### DIFF
--- a/SoftwareOcclusionCulling/CPUT/CPUT/CPUTMeshDX11.cpp
+++ b/SoftwareOcclusionCulling/CPUT/CPUT/CPUTMeshDX11.cpp
@@ -153,8 +153,8 @@ CPUTResult CPUTMeshDX11::CreateNativeResources(
 	memcpy(mpVertexData, pVertexData, pVertexDataInfo[0].mElementCount * mVertexStride);
 	// CC added ends
 
-
-    // create the buffer for the shader resource view
+/* // D3D11_RESOURCE_MISC_BUFFER_STRUCTURED not required by app
+// create the buffer for the shader resource view
     D3D11_BUFFER_DESC desc;
     ZeroMemory( &desc, sizeof(desc) );
     desc.Usage = D3D11_USAGE_DEFAULT;
@@ -184,6 +184,7 @@ CPUTResult CPUTMeshDX11::CreateNativeResources(
     cString name = _L("@VertexBuffer") + ptoc(pModel) + itoc(meshIdx);
     mpVertexBufferForSRV = new CPUTBufferDX11( name, mpVertexBufferForSRVDX, mpVertexView );
     CPUTAssetLibrary::GetAssetLibrary()->AddBuffer( name, mpVertexBufferForSRV );
+*/ // D3D11_RESOURCE_MISC_BUFFER_STRUCTURED not required by app
 
     // build the layout object
     int currentByteOffset=0;

--- a/SoftwareOcclusionCulling/CPUT/CPUT/CPUT_DX11.cpp
+++ b/SoftwareOcclusionCulling/CPUT/CPUT/CPUT_DX11.cpp
@@ -313,6 +313,7 @@ CPUTResult CPUT_DX11::CreateDXContext(CPUTContextCreation ContextParams )
 //-----------------------------------------------------------------------------
 bool CPUT_DX11::TestContextForRequiredFeatures()
 {
+/* // D3D11_RESOURCE_MISC_BUFFER_STRUCTURED not required by app
     // D3D11_RESOURCE_MISC_BUFFER_STRUCTURED check
     // attempt to create a 
     // create the buffer for the shader resource view
@@ -340,6 +341,7 @@ bool CPUT_DX11::TestContextForRequiredFeatures()
         // failed the feature test
         return false;
     }
+ */ // D3D11_RESOURCE_MISC_BUFFER_STRUCTURED not required by app
 
     // add other required features here
 


### PR DESCRIPTION
Removed requirement for D3D11_RESOURCE_MISC_BUFFER_STRUCTURED so that the sample works on DX10+ hardware. The sample doesn't use this buffer or view, so this is a safe change keeping all functionality intact.
